### PR TITLE
Distance Based Ped Spawning

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -48,12 +48,32 @@ function spawnNPC(npcConfig)
 end
 
 CreateThread(function()
-   for i=1, #(Config.NPCs) do
-        spawnNPC(Config.NPCs[i])
-    end
+    while true do
+        Wait(1000) -- Check every second
 
-    if GetCurrentResourceName() ~= "LNWK-NPCs" then
-        print("Please dont edit the resource name :(")
+        local playerPed = PlayerPedId()
+        local playerCoords = GetEntityCoords(playerPed)
+
+        for i, npcConfig in ipairs(Config.NPCs) do
+            local npc = spawnedNPCs[i]
+            local npcExists = npc and DoesEntityExist(npc.ped)
+            local distance = #(playerCoords - npcConfig.coords)
+
+            if distance <= 50.0 then
+                if not npcExists then
+                    spawnNPC(npcConfig) -- Spawn NPC if within range and doesn't exist
+                end
+            else
+                if npcExists then
+                    DeleteEntity(npc.ped) -- Delete NPC if out of range
+                    spawnedNPCs[i] = nil
+                end
+            end
+        end
+
+        if GetCurrentResourceName() ~= "LNWK-NPCs" then
+            print("Please dont edit the resource name :(")
+        end
     end
 end)
 


### PR DESCRIPTION
The Ped pool only has 256 spaces. If filled, it will start deleting drivers from running cars and even player's ped models refuse to spawn in the same routing bucket. This fixes the the issue, spawns and deletes the peds as people get near or farther away